### PR TITLE
feat: Collect custom resources

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -460,7 +460,8 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 		apiResourceListObj, err := data.Get()
 		group := v.Spec.Group
 		if err != nil {
-			errorList[group] = err.Error()
+			errorList[fmt.Sprintf("%s.json", group)] = err.Error()
+			continue
 		}
 		apiResourceList, _ := apiResourceListObj.(*metav1.APIResourceList)
 		groupVersion := apiResourceList.GroupVersion

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -451,7 +451,7 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 	}{}
 	crds, err := client.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		errorList[crds.Kind] = err.Error()
+		errorList["crdList"] = err.Error()
 		return customResources, errorList
 	}
 	// Loop through CRDs to fetch the CRs
@@ -460,7 +460,7 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 		apiResourceListObj, err := data.Get()
 		group := v.Spec.Group
 		if err != nil {
-			errorList[fmt.Sprintf("%s.json", group)] = err.Error()
+			errorList[group] = err.Error()
 			continue
 		}
 		apiResourceList, _ := apiResourceListObj.(*metav1.APIResourceList)

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -472,6 +472,7 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 				customResourcesResponse, err := client.RESTClient().Get().AbsPath("/apis/" + groupVersion).Namespace("").Resource(customResourceName).DoRaw(ctx)
 				if err != nil {
 					errorList[fileName] = err.Error()
+					continue
 				}
 				_ = json.Unmarshal(customResourcesResponse, &customResourceItems)
 				if len(customResourceItems.Items) != 0 {
@@ -479,7 +480,6 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 				}
 			}
 		}
-
 	}
 	//TODO: Improve formatting of the custom resources output
 	return customResources, errorList


### PR DESCRIPTION
This PR enables the collection of Custom Resources as part of the support bundle.

The changes were tested on a kind cluster with Elastic `cloud-on-k8s` CRDs installed. There were 2 elasticsearch clusters in different namespaces 
```bash
➜  k get elasticsearch -A
NAMESPACE   NAME         HEALTH   NODES   VERSION   PHASE   AGE
default     elastic-default   green    1       7.15.0    Ready   11h
test        elastic-test   green    1       7.15.0    Ready   10h 
```
The the custom resouce collector collects the custom resources with running instances under the directory `custom-resources`. The similar resources are collected together according to their `GroupVersion` looking like
```
➜  support-bundle-2021-09-29T14_32_48✗ tree custom-resources 
custom-resources
└── elasticsearches.elasticsearch.k8s.elastic.co.json

0 directories, 1 file
```

If there are multiple `Kinds` in a single `Group`, the resources collected will look somewhat like - 
```
└──kommanderclusters.kommander.mesosphere.io.json
└──licenses.kommander.mesosphere.io.json
```
The version file contains the further data about the custom resources are stored in `Version` named files.
As we have two elasticsearch clusters running in the cluster with the CRD `elasticsearch.k8s.elastic.co` with version `v1`, the file looks like - 
```
{
  "apiVersion":"elasticsearch.k8s.elastic.co/v1",
  "items":[
    {
     ............
      "status":{
        "availableNodes":1,
        "health":"green",
        "phase":"Ready",
        "version":"7.15.0"
      }
    },
    {
      "apiVersion":"elasticsearch.k8s.elastic.co/v1",
      "kind":"Elasticsearch",
      "metadata":{
        "annotations":{
          "common.k8s.elastic.co/controller-version":"1.8.0",
          "elasticsearch.k8s.elastic.co/cluster-uuid":"VAIz8J86S9OMTxMRqp9DuQ",
          "kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"elasticsearch.k8s.elastic.co/v1\",\"kind\":\"Elasticsearch\",\"metadata\":{\"annotations\":{},\"name\":\"elastic-test\",\"namespace\":\"test\"},\"spec\":{\"nodeSets\":[{\"config\":{\"node.store.allow_mmap\":false},\"count\":1,\"name\":\"default\"}],\"version\":\"7.15.0\"}}\n"
        },
        "creationTimestamp":"2021-09-28T07:38:07Z",
        "generation":2,
        "managedFields":[
          {
            "apiVersion":"elasticsearch.k8s.elastic.co/v1",
            "fieldsType":"FieldsV1",
            "fieldsV1":{
            ..................
          {
            "apiVersion":"elasticsearch.k8s.elastic.co/v1",
            "fieldsType":"FieldsV1",
   .............
  "kind":"ElasticsearchList",
  "metadata":{
    "continue":"",
    "resourceVersion":"74852"
  }
}
````

