### PR TITLE
fix: Honour namespaces

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -449,7 +449,7 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 					if !strings.ContainsAny(customResourceName, "/") {
 						customResourcesResponse, err := client.RESTClient().Get().AbsPath("/apis/" + groupVersion).Namespace(namespace).Resource(customResourceName).DoRaw(ctx)
 						if err != nil {
-							errorList[fmt.Sprintf("%s/%s", group, namespace)] = err.Error()
+							errorList[fmt.Sprintf("%s.%s/%s", customResourceName, group, namespace)] = err.Error()
 							continue
 						}
 						_ = json.Unmarshal(customResourcesResponse, &customResourceItems)
@@ -467,7 +467,7 @@ func crs(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextension
 				if !strings.ContainsAny(customResourceName, "/") {
 					customResourcesResponse, err := client.RESTClient().Get().AbsPath("/apis/" + groupVersion).Namespace("").Resource(customResourceName).DoRaw(ctx)
 					if err != nil {
-						errorList[group] = err.Error()
+						errorList[fmt.Sprintf("%s.%s", customResourceName, group)] = err.Error()
 						continue
 					}
 					_ = json.Unmarshal(customResourcesResponse, &customResourceItems)

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -415,11 +415,7 @@ func crds(ctx context.Context, client *apiextensionsv1beta1clientset.Apiextensio
 	return b, nil
 }
 
-func crs(
-	ctx context.Context,
-	client *apiextensionsv1beta1clientset.ApiextensionsV1beta1Client,
-	namespaceNames []string,
-) (map[string][]byte, map[string]string) {
+func crs(ctx context.Context, client *apiextensionsv1beta1clientset.ApiextensionsV1beta1Client, namespaces []string) (map[string][]byte, map[string]string) {
 	customResources := make(map[string][]byte)
 	errorList := make(map[string]string)
 	customResourceItems := struct {
@@ -443,11 +439,17 @@ func crs(
 		}
 		apiResourceList, _ := apiResourceListObj.(*metav1.APIResourceList)
 		groupVersion := apiResourceList.GroupVersion
+
+		var namespace string
+		if len(namespaces) == 1 {
+			namespace = namespaces[0]
+		}
+
 		for _, v := range apiResourceList.APIResources {
 			customResourceName := v.Name
 			if customResourceName != "" && !strings.ContainsAny(customResourceName, "/") {
 				fileName := customResourceName + "." + group + ".json"
-				customResourcesResponse, err := client.RESTClient().Get().AbsPath("/apis/" + groupVersion).Namespace("").Resource(customResourceName).DoRaw(ctx)
+				customResourcesResponse, err := client.RESTClient().Get().AbsPath("/apis/" + groupVersion).Namespace(namespace).Resource(customResourceName).DoRaw(ctx)
 				if err != nil {
 					errorList[fileName] = err.Error()
 					continue


### PR DESCRIPTION
This PR resolves the issue where CRs were collected from all namespaces even if a single namespace was specified. Additionally, it collects the non namespaced objects as well.
The `custom-resources/` directory now looks like
```
support-bundle-2021-10-05T11_50_38/custom-resources
├── custom-resources-errors.json
├── crontabs.stable.example.com
│   ├── prod.json
│   └── test.json
└── elasticsearches.elasticsearch.k8s.elastic.co
    ├── default.json
    ├── prod.json
    └── test.json
```