### PR TITLE
Add option to disable default redactors

### DIFF
--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -16,12 +16,13 @@ import (
 )
 
 type Collector struct {
-	Collect      *troubleshootv1beta2.Collect
-	Redact       bool
-	RBACErrors   []error
-	ClientConfig *rest.Config
-	Namespace    string
-	BundlePath   string
+	Collect                  *troubleshootv1beta2.Collect
+	Redact                   bool
+	DefaultRedactorsDisabled bool
+	RBACErrors               []error
+	ClientConfig             *rest.Config
+	Namespace                string
+	BundlePath               string
 }
 
 type Collectors []*Collector
@@ -269,7 +270,7 @@ func (c *Collector) RunCollectorSync(clientConfig *rest.Config, client kubernete
 	}
 
 	if c.Redact {
-		err = redactResult(c.BundlePath, result, globalRedactors)
+		err = redactResult(c.BundlePath, result, globalRedactors, c.DefaultRedactorsDisabled)
 		err = errors.Wrap(err, "failed to redact")
 	}
 

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -15,7 +15,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/redact"
 )
 
-func redactResult(bundlePath string, input CollectorResult, additionalRedactors []*troubleshootv1beta2.Redact) error {
+func redactResult(bundlePath string, input CollectorResult, additionalRedactors []*troubleshootv1beta2.Redact, defaultRedactorsDisabled bool) error {
 	for k, v := range input {
 		var reader io.Reader
 		if v == nil {
@@ -48,7 +48,7 @@ func redactResult(bundlePath string, input CollectorResult, additionalRedactors 
 			if err != nil {
 				return errors.Wrap(err, "failed to decompress file")
 			}
-			err = redactResult(tmpDir, subResult, additionalRedactors)
+			err = redactResult(tmpDir, subResult, additionalRedactors, defaultRedactorsDisabled)
 			if err != nil {
 				return errors.Wrap(err, "failed to redact file")
 			}
@@ -65,7 +65,7 @@ func redactResult(bundlePath string, input CollectorResult, additionalRedactors 
 			continue
 		}
 
-		redacted, err := redact.Redact(reader, k, additionalRedactors)
+		redacted, err := redact.Redact(reader, k, additionalRedactors, defaultRedactorsDisabled)
 		if err != nil {
 			return errors.Wrap(err, "failed to redact")
 		}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -45,10 +45,14 @@ type Redaction struct {
 	IsDefaultRedactor bool   `json:"isDefaultRedactor" yaml:"isDefaultRedactor"`
 }
 
-func Redact(input io.Reader, path string, additionalRedactors []*troubleshootv1beta2.Redact) (io.Reader, error) {
-	redactors, err := getRedactors(path)
-	if err != nil {
-		return nil, err
+func Redact(input io.Reader, path string, additionalRedactors []*troubleshootv1beta2.Redact, defaultRedactorsDisabled bool) (io.Reader, error) {
+	redactors := []Redactor{}
+	if !defaultRedactorsDisabled {
+		var err error
+		redactors, err = getRedactors(path)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	builtRedactors, err := buildAdditionalRedactors(path, additionalRedactors)

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -22,7 +22,6 @@ import (
 
 // TODO (dan): This is VERY similar to the Preflight collect package and should be refactored.
 func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactors *troubleshootv1beta2.Redactor, bundlePath string, opts SupportBundleCreateOpts) (collect.CollectorResult, error) {
-
 	collectSpecs := make([]*troubleshootv1beta2.Collect, 0)
 	collectSpecs = append(collectSpecs, collectors...)
 	collectSpecs = ensureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
@@ -31,11 +30,12 @@ func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactor
 	var cleanedCollectors collect.Collectors
 	for _, desiredCollector := range collectSpecs {
 		collector := collect.Collector{
-			Redact:       true,
-			Collect:      desiredCollector,
-			ClientConfig: opts.KubernetesRestConfig,
-			Namespace:    opts.Namespace,
-			BundlePath:   bundlePath,
+			Redact:                   true,
+			DefaultRedactorsDisabled: opts.DefaultRedactorsDisabled,
+			Collect:                  desiredCollector,
+			ClientConfig:             opts.KubernetesRestConfig,
+			Namespace:                opts.Namespace,
+			BundlePath:               bundlePath,
 		}
 		cleanedCollectors = append(cleanedCollectors, &collector)
 	}
@@ -159,7 +159,6 @@ func getAnalysisFile(analyzeResults []*analyze.AnalyzeResult) (io.Reader, error)
 }
 
 func applyLogSinceTime(sinceTime time.Time, collectors *collect.Collectors) {
-
 	for _, collector := range *collectors {
 		if collector.Collect.Logs != nil {
 			if collector.Collect.Logs.Limits == nil {

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -27,6 +27,7 @@ type SupportBundleCreateOpts struct {
 	ProgressChan              chan interface{}
 	SinceTime                 *time.Time
 	FromCLI                   bool
+	DefaultRedactorsDisabled  bool
 }
 
 type SupportBundleResponse struct {


### PR DESCRIPTION
Adds a new option to disable the default, hardcoded redactors.
Jira ticket: [D2IQ-79853](https://jira.d2iq.com/browse/D2IQ-79853)

A simpler "pragmatic" alternative (in case we don't want to get the changes upstream):
https://github.com/mesosphere/troubleshoot/compare/v0.13-d2iq...mesosphere:florian/dont_redact_ips_simple