### PR TITLE
fix: Show proper names of ExecCopyFromHost and AllPods collectors

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -456,6 +456,11 @@ func (c *Collect) GetName() string {
 		name = c.Logs.CollectorName
 		selector = strings.Join(c.Logs.Selector, ",")
 	}
+	if c.AllLogs != nil {
+		collector = "all-logs"
+		name = c.AllLogs.CollectorName
+		selector = strings.Join(c.AllLogs.Selector, ",")
+	}
 	if c.Run != nil {
 		collector = "run"
 		name = c.Run.CollectorName
@@ -489,6 +494,10 @@ func (c *Collect) GetName() string {
 	if c.Ceph != nil {
 		collector = "ceph"
 		name = c.Ceph.CollectorName
+	}
+	if c.ExecCopyFromHost != nil {
+		collector = "exec-copy-from-host"
+		name = c.ExecCopyFromHost.CollectorName
 	}
 	if c.Longhorn != nil {
 		collector = "longhorn"


### PR DESCRIPTION
It was spotted during testing that `ExecCopyFromHost` collector was displayed as `<none>` while collecting the diagnostics. 
```
Collecting support bundle ⠧ <none>
```
This PR fixes this issue and also adds proper display name to the `AllLogs` collector.