### PR TITLE
fix: Add timestamp in *-error.txt files from execcopyfromhost collector

### DIFF
--- a/pkg/collect/exec_copy_from_host.go
+++ b/pkg/collect/exec_copy_from_host.go
@@ -359,7 +359,8 @@ func execCopyFromHostGetFilesFromPods(
 			// Save pod status
 			podJson, err := json.MarshalIndent(pod, "", "  ")
 			if err != nil {
-				output.SaveResult(c.BundlePath, filepath.Join(outputNodePath, "pod-collector-marshall-error.txt"), bytes.NewReader([]byte(err.Error())))
+				timestampedErr := fmt.Sprintf("[%s] %s", time.Now().String(), err.Error())
+				output.SaveResult(c.BundlePath, filepath.Join(outputNodePath, "pod-collector-marshall-error.txt"), bytes.NewReader([]byte(timestampedErr)))
 			} else {
 				output.SaveResult(c.BundlePath, filepath.Join(outputNodePath, "pod-collector.json"), bytes.NewReader(podJson))
 			}
@@ -369,7 +370,8 @@ func execCopyFromHostGetFilesFromPods(
 				logPath := filepath.Join(outputNodePath, fmt.Sprintf("pod-%s", initContainer.Name))
 				copyContainerLogsResult, copyErr := copyContainerLogs(ctx, c.BundlePath, clientSet, pod, initContainer.Name, logPath, false)
 				if copyErr != nil {
-					output.SaveResult(c.BundlePath, fmt.Sprintf("%s-log-copy-error.txt", logPath), bytes.NewReader([]byte(copyErr.Error())))
+					timestampedCopyErr := fmt.Sprintf("[%s] %s", time.Now().String(), copyErr.Error())
+					output.SaveResult(c.BundlePath, fmt.Sprintf("%s-log-copy-error.txt", logPath), bytes.NewReader([]byte(timestampedCopyErr)))
 				} else {
 					copyResultsToOutput(output, copyContainerLogsResult)
 				}


### PR DESCRIPTION
Currently, the `file-copy-error.txt` file shows errors like
```
failed to copy data from the pod container pause: failed to stream command output: unable to upgrade connection: container not found ("pause")
```
This PR adds timestamp to the above error messsage
```
[2021-10-10 23:00:00 +0000 UTC m=+0.000000001] failed to copy data from the pod container pause: failed to stream command output: unable to upgrade connection: container not found ("pause")
```
