### PR TITLE
fix: add option to run ExecCopyFromHost container with host ns

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -160,6 +160,10 @@ type ExecCopyFromHost struct {
 	Capabilities     []string `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	RunAsUser        int64    `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
 	RunAsNonRoot     bool     `json:"runAsNonRoot,omitempty" yaml:"runAsNonRoot,omitempty"`
+	// Enable to run with various host NS
+	HostNetwork bool `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
+	HostIPC     bool `json:"hostIPC,omitempty" yaml:"hostIPC,omitempty"`
+	HostPID     bool `json:"hostPID,omitempty" yaml:"hostPID,omitempty"`
 	// DataPath         string   `json:"dataPath" yaml:"dataPath"`
 	ExtractArchive bool `json:"extractArchive,omitempty" yaml:"extractArchive,omitempty"`
 }

--- a/pkg/collect/exec_copy_from_host.go
+++ b/pkg/collect/exec_copy_from_host.go
@@ -171,6 +171,9 @@ func execCopyFromHostCreateDaemonSet(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyAlways,
+					HostNetwork:   collector.HostNetwork,
+					HostPID:       collector.HostPID,
+					HostIPC:       collector.HostIPC,
 					InitContainers: []corev1.Container{
 						{
 							Name:            "collector",


### PR DESCRIPTION
Diagnostics script requires running with host networking, pid and IPC namespaces to correctly collect data from some tools like `iptables` or `systemctl`.

JIRA: https://jira.d2iq.com/browse/D2IQ-85636