### PR TITLE
chore: honor NamePrefix in bundle name

### DIFF
--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -70,7 +70,7 @@ func CollectSupportBundleFromSpec(spec *troubleshootv1beta2.SupportBundleSpec, a
 		basename = strings.TrimSuffix(overridePath, ".tar.gz")
 	} else {
 		// use default output path
-		basename = fmt.Sprintf("support-bundle-%s", time.Now().Format("2006-01-02T15_04_05"))
+		basename = fmt.Sprintf("%ssupport-bundle-%s", opts.NamePrefix, time.Now().Format("2006-01-02T15_04_05"))
 		if !opts.FromCLI {
 			basename = filepath.Join(os.TempDir(), basename)
 		}


### PR DESCRIPTION
During conflict resolution from merge of `v0.26-d2iq` into `v0.37.1-d2iq` in #28 i did not resolve the conflicts correctly when merging https://github.com/mesosphere/troubleshoot/blob/v0.26-d2iq/pkg/supportbundle/supportbundle.go#L61 into [`c2ed475` (#28)](https://github.com/mesosphere/troubleshoot/pull/28/commits/c2ed4757268eb1d3c0a732f1d2d2313c517a7288#diff-04328572fa60f5b4cdaaa40835e6d53387d06e87f3e4becf95ab471678323bb6R23)

This change ensures that the `NamePrefix` is honored (as it always was).